### PR TITLE
updating data_pipeline.md comparing ETL, ELT, and EtLT pipelines

### DIFF
--- a/data_pipeline.md
+++ b/data_pipeline.md
@@ -55,7 +55,7 @@ before loading (e.g., masking PII, filtering illegal fields), and a
 second, more complex transformation occurs inside the warehouse.
 
 **Process:**
-1. **Extract** – Raw data is pulled from source systems
+1. **Extract** –  The Raw data is pulled from source systems . mm
 2. **transform** – A minimal transformation strips or masks sensitive
    fields (lowercase "t" = lightweight, not full restructuring)
 3. **Load** – Partially cleaned data enters the warehouse


### PR DESCRIPTION
Why this change was made:
Documents the three main data pipeline architectures and contrasts their compliance implications. ETL transforms before loading, keeping sensitive data out of the warehouse. ELT loads raw data first, which may conflict with data minimisation regulations. EtLT combines both approaches for flexibility and auditability.

 Close #6 


